### PR TITLE
feat: add basic auth with author role

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,30 @@
 </head>
 <body>
 <h1>Airline Callsign Finder</h1>
+
+<div id="auth-section">
+    <div id="login-form">
+        <input type="text" id="username" placeholder="Benutzername">
+        <input type="password" id="password" placeholder="Passwort">
+        <button id="login-btn">Login</button>
+    </div>
+    <div id="logout-section" class="hidden">
+        Eingeloggt als <span id="current-user"></span>
+        <button id="logout-btn">Logout</button>
+    </div>
+</div>
+
 <input type="text" id="icao-input" placeholder="ICAO-Code eingeben (z. B. DLH)">
 <ul id="suggestions"></ul>
 
+<div id="crud-section" class="hidden">
+    <h2>Airlines verwalten</h2>
+    <input type="text" id="new-icao" placeholder="ICAO">
+    <input type="text" id="new-callsign" placeholder="Callsign">
+    <button id="add-airline">Hinzufügen</button>
+    <ul id="airline-list"></ul>
+</div>
+
 <script src="script.js"></script>
-<script>
-    if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('sw.js')
-            .then(() => console.log('Service Worker registriert'))
-            .catch(err => console.log('Fehler beim Registrieren:', err));
-    }
-</script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,21 +1,112 @@
 let airlines = {};
+let currentUser = JSON.parse(localStorage.getItem('user')) || null;
 
-fetch('airlines.json')
-    .then(response => response.json())
-    .then(data => airlines = data);
+const storedAirlines = localStorage.getItem('airlines');
+if (storedAirlines) {
+    airlines = JSON.parse(storedAirlines);
+} else {
+    fetch('airlines.json')
+        .then(response => response.json())
+        .then(data => {
+            airlines = data;
+            localStorage.setItem('airlines', JSON.stringify(airlines));
+            if (currentUser?.role === 'author') renderAirlineList();
+        });
+}
+
+const users = {
+    author: { password: 'secret', role: 'author' }
+};
+
+const loginForm = document.getElementById('login-form');
+const logoutSection = document.getElementById('logout-section');
+const currentUserSpan = document.getElementById('current-user');
+
+const crudSection = document.getElementById('crud-section');
+const airlineList = document.getElementById('airline-list');
+
+function updateUI() {
+    if (currentUser) {
+        loginForm.classList.add('hidden');
+        logoutSection.classList.remove('hidden');
+        currentUserSpan.textContent = `${currentUser.username} (${currentUser.role})`;
+        if (currentUser.role === 'author') {
+            crudSection.classList.remove('hidden');
+            renderAirlineList();
+        } else {
+            crudSection.classList.add('hidden');
+        }
+    } else {
+        loginForm.classList.remove('hidden');
+        logoutSection.classList.add('hidden');
+        crudSection.classList.add('hidden');
+    }
+}
+
+updateUI();
+
+document.getElementById('login-btn').addEventListener('click', () => {
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const user = users[username];
+    if (user && user.password === password) {
+        currentUser = { username, role: user.role };
+        localStorage.setItem('user', JSON.stringify(currentUser));
+        updateUI();
+    } else {
+        alert('Login fehlgeschlagen');
+    }
+});
+
+document.getElementById('logout-btn').addEventListener('click', () => {
+    currentUser = null;
+    localStorage.removeItem('user');
+    updateUI();
+});
+
+function renderAirlineList() {
+    airlineList.innerHTML = '';
+    Object.keys(airlines).forEach(icao => {
+        const li = document.createElement('li');
+        li.textContent = `${icao} - ${airlines[icao]}`;
+        const del = document.createElement('button');
+        del.textContent = 'Löschen';
+        del.addEventListener('click', () => {
+            if (!(currentUser?.role === 'author')) return;
+            delete airlines[icao];
+            localStorage.setItem('airlines', JSON.stringify(airlines));
+            renderAirlineList();
+        });
+        li.appendChild(del);
+        airlineList.appendChild(li);
+    });
+}
+
+document.getElementById('add-airline').addEventListener('click', () => {
+    if (!(currentUser?.role === 'author')) return;
+    const icao = document.getElementById('new-icao').value.toUpperCase();
+    const callsign = document.getElementById('new-callsign').value;
+    if (icao && callsign) {
+        airlines[icao] = callsign;
+        localStorage.setItem('airlines', JSON.stringify(airlines));
+        document.getElementById('new-icao').value = '';
+        document.getElementById('new-callsign').value = '';
+        renderAirlineList();
+    }
+});
 
 const input = document.getElementById('icao-input');
 const suggestions = document.getElementById('suggestions');
 
 input.addEventListener('input', function () {
     const query = this.value.toUpperCase();
-    suggestions.innerHTML = ''; // Vorherige Vorschläge löschen
+    suggestions.innerHTML = '';
 
     if (query.length === 0) return;
 
     const matches = Object.keys(airlines)
         .filter(icao => icao.startsWith(query))
-        .map(icao => ({icao, callsign: airlines[icao]}));
+        .map(icao => ({ icao, callsign: airlines[icao] }));
 
     matches.forEach(a => {
         const li = document.createElement('li');
@@ -27,3 +118,9 @@ input.addEventListener('input', function () {
         suggestions.appendChild(li);
     });
 });
+
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js')
+        .then(() => console.log('Service Worker registriert'))
+        .catch(err => console.log('Fehler beim Registrieren:', err));
+}

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,10 @@ body {
     margin: 50px;
 }
 
+.hidden {
+    display: none;
+}
+
 input {
     width: 80%;
     padding: 10px;
@@ -34,4 +38,23 @@ li span:first-child {
 
 li:hover {
     background-color: #f0f0f0;
+}
+
+#auth-section, #crud-section {
+    margin-top: 20px;
+}
+
+#login-form input,
+#crud-section input {
+    width: auto;
+    margin: 5px;
+    padding: 5px;
+}
+
+#airline-list li {
+    align-items: center;
+}
+
+#airline-list li button {
+    margin-left: 10px;
 }


### PR DESCRIPTION
## Summary
- add login/logout UI and author-only management section
- implement simple in-browser authentication storing role in localStorage
- restrict CRUD operations to users with `author` role
- move service worker registration to script.js and replace inline display styles with `.hidden` class

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898a5f070d08321a7d230d58300c2b3