### PR TITLE
Add Express backend and connect frontend to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.2"
+  }
 }

--- a/script.js
+++ b/script.js
@@ -1,18 +1,16 @@
 let airlines = {};
 let currentUser = JSON.parse(localStorage.getItem('user')) || null;
 
-const storedAirlines = localStorage.getItem('airlines');
-if (storedAirlines) {
-    airlines = JSON.parse(storedAirlines);
-} else {
-    fetch('airlines.json')
+function loadAirlines() {
+    return fetch('/api/airlines')
         .then(response => response.json())
         .then(data => {
             airlines = data;
-            localStorage.setItem('airlines', JSON.stringify(airlines));
             if (currentUser?.role === 'author') renderAirlineList();
         });
 }
+
+loadAirlines();
 
 const users = {
     author: { password: 'secret', role: 'author' }
@@ -53,6 +51,7 @@ document.getElementById('login-btn').addEventListener('click', () => {
         currentUser = { username, role: user.role };
         localStorage.setItem('user', JSON.stringify(currentUser));
         updateUI();
+        if (currentUser.role === 'author') loadAirlines();
     } else {
         alert('Login fehlgeschlagen');
     }
@@ -73,9 +72,10 @@ function renderAirlineList() {
         del.textContent = 'Löschen';
         del.addEventListener('click', () => {
             if (!(currentUser?.role === 'author')) return;
-            delete airlines[icao];
-            localStorage.setItem('airlines', JSON.stringify(airlines));
-            renderAirlineList();
+            fetch(`/api/airlines/${icao}`, {
+                method: 'DELETE',
+                headers: { 'X-Role': currentUser.role }
+            }).then(loadAirlines);
         });
         li.appendChild(del);
         airlineList.appendChild(li);
@@ -87,11 +87,18 @@ document.getElementById('add-airline').addEventListener('click', () => {
     const icao = document.getElementById('new-icao').value.toUpperCase();
     const callsign = document.getElementById('new-callsign').value;
     if (icao && callsign) {
-        airlines[icao] = callsign;
-        localStorage.setItem('airlines', JSON.stringify(airlines));
-        document.getElementById('new-icao').value = '';
-        document.getElementById('new-callsign').value = '';
-        renderAirlineList();
+        fetch('/api/airlines', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Role': currentUser.role
+            },
+            body: JSON.stringify({ icao, callsign })
+        }).then(() => {
+            document.getElementById('new-icao').value = '';
+            document.getElementById('new-callsign').value = '';
+            loadAirlines();
+        });
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+app.use(express.json());
+app.use(express.static(__dirname));
+
+const DATA_FILE = path.join(__dirname, 'airlines.json');
+
+function readData() {
+  return JSON.parse(fs.readFileSync(DATA_FILE));
+}
+
+function writeData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function requireAuthor(req, res, next) {
+  if (req.header('x-role') !== 'author') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+
+app.get('/api/airlines', (req, res) => {
+  res.json(readData());
+});
+
+app.get('/api/airlines/:icao', (req, res) => {
+  const data = readData();
+  const icao = req.params.icao.toUpperCase();
+  const callsign = data[icao];
+  if (!callsign) return res.status(404).end();
+  res.json({ icao, callsign });
+});
+
+app.post('/api/airlines', requireAuthor, (req, res) => {
+  const { icao, callsign } = req.body;
+  if (!icao || !callsign) {
+    return res.status(400).json({ error: 'icao and callsign required' });
+  }
+  const data = readData();
+  data[icao.toUpperCase()] = callsign;
+  writeData(data);
+  res.status(201).json({ icao: icao.toUpperCase(), callsign });
+});
+
+app.put('/api/airlines/:icao', requireAuthor, (req, res) => {
+  const { callsign } = req.body;
+  const icao = req.params.icao.toUpperCase();
+  const data = readData();
+  if (!data[icao]) return res.status(404).end();
+  data[icao] = callsign;
+  writeData(data);
+  res.json({ icao, callsign });
+});
+
+app.delete('/api/airlines/:icao', requireAuthor, (req, res) => {
+  const icao = req.params.icao.toUpperCase();
+  const data = readData();
+  if (!data[icao]) return res.status(404).end();
+  delete data[icao];
+  writeData(data);
+  res.status(204).end();
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- build Express server with CRUD endpoints on `/api/airlines`
- verify `author` role before allowing POST/PUT/DELETE
- rework frontend to load and modify airline data via API instead of `airlines.json`
- add Express dependency and start script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa7f8f248321a5a8727f5631d484