### PR TITLE
feat: improve caching and offline sync

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,6 +30,28 @@ const cancelEditBtn = document.getElementById('cancel-edit');
 const messageBox = document.getElementById('message');
 let editTarget = null;
 
+function invalidateAirlineCache() {
+    if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'invalidate-airlines-cache' });
+    }
+}
+
+function queueOperation(operation) {
+    if ('serviceWorker' in navigator && 'SyncManager' in window) {
+        navigator.serviceWorker.ready
+            .then(reg => {
+                if (navigator.serviceWorker.controller) {
+                    navigator.serviceWorker.controller.postMessage({ type: 'queue', operation });
+                }
+                return reg.sync.register('sync-airlines');
+            })
+            .then(() => showMessage('Offline gespeichert, wird später synchronisiert'))
+            .catch(() => showMessage('Fehler beim Offline-Speichern', true));
+    } else {
+        showMessage('Offline-Sync nicht unterstützt', true);
+    }
+}
+
 function showMessage(text, isError = false) {
     messageBox.textContent = text;
     messageBox.className = isError ? 'error' : 'success';
@@ -109,10 +131,20 @@ function deleteAirline(icao) {
         method: 'DELETE',
         headers: { 'X-Role': currentUser.role }
     }).then(res => {
-        if (!res.ok) throw new Error();
-        showMessage('Airline gelöscht');
-        loadAirlines();
-    }).catch(() => showMessage('Fehler beim Löschen', true));
+        if (res.ok) {
+            showMessage('Airline gelöscht');
+            invalidateAirlineCache();
+            loadAirlines();
+        } else {
+            showMessage('Fehler beim Löschen', true);
+        }
+    }).catch(() => {
+        queueOperation({
+            method: 'DELETE',
+            url: `/api/airlines/${icao}`,
+            headers: { 'X-Role': currentUser.role }
+        });
+    });
 }
 
 function startEdit(icao, callsign) {
@@ -142,8 +174,19 @@ addForm.addEventListener('submit', e => {
             document.getElementById('new-icao').value = '';
             document.getElementById('new-callsign').value = '';
             showMessage('Airline hinzugefügt');
+            invalidateAirlineCache();
             loadAirlines();
-        }).catch(() => showMessage('Fehler beim Hinzufügen', true));
+        }).catch(() => {
+            queueOperation({
+                method: 'POST',
+                url: '/api/airlines',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Role': currentUser.role
+                },
+                body: { icao, callsign }
+            });
+        });
     }
 });
 
@@ -165,8 +208,19 @@ editForm.addEventListener('submit', e => {
         editForm.classList.add('hidden');
         editCallsignInput.value = '';
         editTarget = null;
+        invalidateAirlineCache();
         loadAirlines();
-    }).catch(() => showMessage('Fehler beim Aktualisieren', true));
+    }).catch(() => {
+        queueOperation({
+            method: 'PUT',
+            url: `/api/airlines/${editTarget}`,
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Role': currentUser.role
+            },
+            body: { callsign: editCallsignInput.value }
+        });
+    });
 });
 
 cancelEditBtn.addEventListener('click', () => {
@@ -217,4 +271,11 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js')
         .then(() => console.log('Service Worker registriert'))
         .catch(err => console.log('Fehler beim Registrieren:', err));
+
+    navigator.serviceWorker.addEventListener('message', event => {
+        if (event.data?.type === 'sync-complete') {
+            showMessage('Änderungen synchronisiert');
+            loadAirlines();
+        }
+    });
 }

--- a/sw.js
+++ b/sw.js
@@ -1,24 +1,87 @@
-const CACHE_NAME = 'pwa-cache-v1';
+const CACHE_NAME = 'pwa-cache-v2';
 const FILES_TO_CACHE = [
-    '/',
-    '/index.html',
-    '/styles.css',
-    '/script.js',
-    '/airlines.json',
-    '/icon-192.png',
-    '/icon-512.png'
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/script.js',
+  '/airlines.json',
+  '/icon-192.png',
+  '/icon-512.png'
 ];
+const QUEUE_NAME = 'airline-queue';
 
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(CACHE_NAME)
-            .then((cache) => cache.addAll(FILES_TO_CACHE))
-    );
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
+  );
 });
 
-self.addEventListener('fetch', (event) => {
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.url.includes('/api/')) {
     event.respondWith(
-        caches.match(event.request)
-            .then((response) => response || fetch(event.request))
+      fetch(request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match(request))
     );
+    return;
+  }
+  event.respondWith(
+    caches.match(request).then(response => response || fetch(request))
+  );
 });
+
+self.addEventListener('message', event => {
+  if (event.data?.type === 'invalidate-airlines-cache') {
+    caches.open(CACHE_NAME).then(cache => cache.delete('/api/airlines'));
+  } else if (event.data?.type === 'queue') {
+    storeOperation(event.data.operation);
+  }
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sync-airlines') {
+    event.waitUntil(processQueue());
+  }
+});
+
+function storeOperation(operation) {
+  return caches.open(QUEUE_NAME).then(cache => {
+    const id = Date.now();
+    const request = new Request(`/queue/${id}`, { method: 'POST' });
+    const response = new Response(JSON.stringify(operation));
+    return cache.put(request, response);
+  });
+}
+
+function processQueue() {
+  return caches
+    .open(QUEUE_NAME)
+    .then(cache =>
+      cache.keys().then(keys =>
+        Promise.all(
+          keys.map(key =>
+            cache.match(key).then(res =>
+              res.json().then(op =>
+                fetch(op.url, {
+                  method: op.method,
+                  headers: op.headers,
+                  body: op.body ? JSON.stringify(op.body) : undefined
+                }).then(() => cache.delete(key))
+              )
+            )
+          )
+        )
+      )
+    )
+    .then(() => caches.open(CACHE_NAME).then(cache => cache.delete('/api/airlines')))
+    .then(() =>
+      self.clients.matchAll().then(clients => {
+        clients.forEach(client => client.postMessage({ type: 'sync-complete' }));
+      })
+    );
+}


### PR DESCRIPTION
## Summary
- switch service worker to network-first caching for API requests
- invalidate airline cache after CRUD operations
- queue offline edits with background sync

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898afc12cdc832185dcdde3351bac51