### PR TITLE
Add JWT-based auth and protected routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,57 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const jwt = require('../auth/jwt');
+const app = require('../server');
+
+const DATA_FILE = path.join(__dirname, '..', 'airlines.json');
+let originalData;
+
+beforeEach(() => {
+  originalData = fs.readFileSync(DATA_FILE, 'utf-8');
+});
+
+afterEach(() => {
+  fs.writeFileSync(DATA_FILE, originalData);
+});
+
+describe('Authentication', () => {
+  test('login fails with wrong credentials', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ username: 'author', password: 'wrong' });
+    expect(res.status).toBe(401);
+  });
+
+  test('invalid token is rejected', async () => {
+    const loginRes = await request(app)
+      .post('/api/login')
+      .send({ username: 'author', password: 'secret' });
+    const token = loginRes.body.token;
+    const badToken = token + 'x';
+    const res = await request(app)
+      .post('/api/airlines')
+      .set('Authorization', `Bearer ${badToken}`)
+      .send({ icao: 'INV', callsign: 'Invalid' });
+    expect(res.status).toBe(403);
+  });
+
+  test('role-based access', async () => {
+    const userToken = jwt.sign({ username: 'user', role: 'user' }, 'supersecret');
+    let res = await request(app)
+      .post('/api/airlines')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ icao: 'TST', callsign: 'Test' });
+    expect(res.status).toBe(403);
+
+    const loginRes = await request(app)
+      .post('/api/login')
+      .send({ username: 'author', password: 'secret' });
+    const token = loginRes.body.token;
+    res = await request(app)
+      .post('/api/airlines')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ icao: 'TST', callsign: 'Test' });
+    expect(res.status).toBe(201);
+  });
+});

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -31,16 +31,21 @@ describe('Airline API', () => {
     expect(res404.status).toBe(404);
   });
 
-  test('POST, PUT, DELETE require x-role: author and persist data changes', async () => {
+  test('POST, PUT, DELETE require auth token and persist data changes', async () => {
     const code = 'TST';
     const callsign = 'TestAir';
 
     let res = await request(app).post('/api/airlines').send({ icao: code, callsign });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
+
+    const loginRes = await request(app)
+      .post('/api/login')
+      .send({ username: 'author', password: 'secret' });
+    const token = loginRes.body.token;
 
     res = await request(app)
       .post('/api/airlines')
-      .set('x-role', 'author')
+      .set('Authorization', `Bearer ${token}`)
       .send({ icao: code, callsign });
     expect(res.status).toBe(201);
 
@@ -49,11 +54,11 @@ describe('Airline API', () => {
     expect(res.body.callsign).toBe(callsign);
 
     res = await request(app).put(`/api/airlines/${code}`).send({ callsign: 'Updated' });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
 
     res = await request(app)
       .put(`/api/airlines/${code}`)
-      .set('x-role', 'author')
+      .set('Authorization', `Bearer ${token}`)
       .send({ callsign: 'Updated' });
     expect(res.status).toBe(200);
 
@@ -61,9 +66,11 @@ describe('Airline API', () => {
     expect(res.body.callsign).toBe('Updated');
 
     res = await request(app).delete(`/api/airlines/${code}`);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
 
-    res = await request(app).delete(`/api/airlines/${code}`).set('x-role', 'author');
+    res = await request(app)
+      .delete(`/api/airlines/${code}`)
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(204);
 
     res = await request(app).get(`/api/airlines/${code}`);

--- a/auth/bcrypt.js
+++ b/auth/bcrypt.js
@@ -1,0 +1,15 @@
+const crypto = require('crypto');
+
+function hash(password) {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derived = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+  return `${salt}:${derived}`;
+}
+
+function compare(password, hashed) {
+  const [salt, key] = hashed.split(':');
+  const derived = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+  return derived === key;
+}
+
+module.exports = { hash, compare };

--- a/auth/index.js
+++ b/auth/index.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const bcrypt = require('./bcrypt');
+const jwt = require('./jwt');
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'supersecret';
+
+const users = [
+  { username: 'author', passwordHash: bcrypt.hash('secret'), role: 'author' }
+];
+
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user || !bcrypt.compare(password, user.passwordHash)) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ username: user.username, role: user.role }, SECRET);
+  res.json({ token });
+});
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'No token provided' });
+  try {
+    const user = jwt.verify(token, SECRET);
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(403).json({ error: 'Invalid token' });
+  }
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}
+
+module.exports = { router, authenticateToken, requireRole };

--- a/auth/jwt.js
+++ b/auth/jwt.js
@@ -1,0 +1,38 @@
+const crypto = require('crypto');
+
+function base64url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function sign(payload, secret) {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const signature = base64url(
+    crypto.createHmac('sha256', secret).update(data).digest()
+  );
+  return `${data}.${signature}`;
+}
+
+function verify(token, secret, cb) {
+  try {
+    const [header, body, signature] = token.split('.');
+    const data = `${header}.${body}`;
+    const expected = base64url(
+      crypto.createHmac('sha256', secret).update(data).digest()
+    );
+    if (expected !== signature) throw new Error('invalid signature');
+    const payload = JSON.parse(Buffer.from(body, 'base64').toString());
+    if (cb) cb(null, payload);
+    return payload;
+  } catch (err) {
+    if (cb) cb(err);
+    else throw err;
+  }
+}
+
+module.exports = { sign, verify };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "private": true,
   "dependencies": {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,14 @@
 let airlines = {};
-let currentUser = JSON.parse(localStorage.getItem('user')) || null;
+let token = localStorage.getItem('token');
+let currentUser = token ? parseJwt(token) : null;
+
+function parseJwt(t) {
+    try {
+        return JSON.parse(atob(t.split('.')[1]));
+    } catch {
+        return null;
+    }
+}
 
 function loadAirlines() {
     return fetch('/api/airlines')
@@ -11,10 +20,6 @@ function loadAirlines() {
 }
 
 loadAirlines();
-
-const users = {
-    author: { password: 'secret', role: 'author' }
-};
 
 const loginForm = document.getElementById('login-form');
 const logoutSection = document.getElementById('logout-section');
@@ -84,20 +89,28 @@ updateUI();
 document.getElementById('login-btn').addEventListener('click', () => {
     const username = document.getElementById('username').value;
     const password = document.getElementById('password').value;
-    const user = users[username];
-    if (user && user.password === password) {
-        currentUser = { username, role: user.role };
-        localStorage.setItem('user', JSON.stringify(currentUser));
+    fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+    }).then(res => {
+        if (!res.ok) throw new Error();
+        return res.json();
+    }).then(data => {
+        token = data.token;
+        localStorage.setItem('token', token);
+        currentUser = parseJwt(token);
         updateUI();
         if (currentUser.role === 'author') loadAirlines();
-    } else {
+    }).catch(() => {
         alert('Login fehlgeschlagen');
-    }
+    });
 });
 
 document.getElementById('logout-btn').addEventListener('click', () => {
     currentUser = null;
-    localStorage.removeItem('user');
+    token = null;
+    localStorage.removeItem('token');
     updateUI();
 });
 
@@ -129,7 +142,7 @@ function deleteAirline(icao) {
     if (!(currentUser?.role === 'author')) return;
     fetch(`/api/airlines/${icao}`, {
         method: 'DELETE',
-        headers: { 'X-Role': currentUser.role }
+        headers: { 'Authorization': `Bearer ${token}` }
     }).then(res => {
         if (res.ok) {
             showMessage('Airline gelöscht');
@@ -142,7 +155,7 @@ function deleteAirline(icao) {
         queueOperation({
             method: 'DELETE',
             url: `/api/airlines/${icao}`,
-            headers: { 'X-Role': currentUser.role }
+            headers: { 'Authorization': `Bearer ${token}` }
         });
     });
 }
@@ -164,7 +177,7 @@ addForm.addEventListener('submit', e => {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-Role': currentUser.role
+                'Authorization': `Bearer ${token}`
             },
             body: JSON.stringify({ icao, callsign })
         }).then(res => {
@@ -182,7 +195,7 @@ addForm.addEventListener('submit', e => {
                 url: '/api/airlines',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-Role': currentUser.role
+                    'Authorization': `Bearer ${token}`
                 },
                 body: { icao, callsign }
             });
@@ -197,7 +210,7 @@ editForm.addEventListener('submit', e => {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            'X-Role': currentUser.role
+            'Authorization': `Bearer ${token}`
         },
         body: JSON.stringify({ callsign: editCallsignInput.value })
     }).then(res => {
@@ -216,7 +229,7 @@ editForm.addEventListener('submit', e => {
             url: `/api/airlines/${editTarget}`,
             headers: {
                 'Content-Type': 'application/json',
-                'X-Role': currentUser.role
+                'Authorization': `Bearer ${token}`
             },
             body: { callsign: editCallsignInput.value }
         });

--- a/server.js
+++ b/server.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const { router: authRouter, authenticateToken, requireRole } = require('./auth');
 
 const app = express();
 app.use(express.json());
 app.use(express.static(__dirname));
+app.use('/api', authRouter);
 
 const DATA_FILE = path.join(__dirname, 'airlines.json');
 
@@ -16,12 +18,7 @@ function writeData(data) {
   fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
 }
 
-function requireAuthor(req, res, next) {
-  if (req.header('x-role') !== 'author') {
-    return res.status(403).json({ error: 'Forbidden' });
-  }
-  next();
-}
+const requireAuthor = requireRole('author');
 
 app.get('/api/airlines', (req, res) => {
   res.json(readData());
@@ -35,7 +32,7 @@ app.get('/api/airlines/:icao', (req, res) => {
   res.json({ icao, callsign });
 });
 
-app.post('/api/airlines', requireAuthor, (req, res) => {
+app.post('/api/airlines', authenticateToken, requireAuthor, (req, res) => {
   const { icao, callsign } = req.body;
   if (!icao || !callsign) {
     return res.status(400).json({ error: 'icao and callsign required' });
@@ -46,7 +43,7 @@ app.post('/api/airlines', requireAuthor, (req, res) => {
   res.status(201).json({ icao: icao.toUpperCase(), callsign });
 });
 
-app.put('/api/airlines/:icao', requireAuthor, (req, res) => {
+app.put('/api/airlines/:icao', authenticateToken, requireAuthor, (req, res) => {
   const { callsign } = req.body;
   const icao = req.params.icao.toUpperCase();
   const data = readData();
@@ -56,7 +53,7 @@ app.put('/api/airlines/:icao', requireAuthor, (req, res) => {
   res.json({ icao, callsign });
 });
 
-app.delete('/api/airlines/:icao', requireAuthor, (req, res) => {
+app.delete('/api/airlines/:icao', authenticateToken, requireAuthor, (req, res) => {
   const icao = req.params.icao.toUpperCase();
   const data = readData();
   if (!data[icao]) return res.status(404).end();


### PR DESCRIPTION
## Summary
- introduce custom auth module for password hashing and JWT token generation
- secure airline CRUD endpoints with token verification and role checks
- switch frontend to login against API and send Bearer tokens instead of static roles
- add Jest tests for authentication, token validation, and role-based access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b9b7a58c8321b45eb653b4cdb5b6