### PR TITLE
Add dotenv configuration and request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # airline-callsign-finder
-This PWA is for a friend of mine
+
+This PWA is for a friend of mine.
+
+## Environment Variables
+
+The server reads configuration from environment variables using [`dotenv`](https://www.npmjs.com/package/dotenv).
+Create a `.env` file or export variables in your shell.
+
+- `PORT`: Port number for the HTTP server (defaults to `3000`).
+- `DATA_PATH`: Path to the `airlines.json` data file (defaults to the copy in this repository).
+
+## Logging
+
+HTTP requests are logged using [`morgan`](https://www.npmjs.com/package/morgan).
+In production (`NODE_ENV=production`) logs are written to stdout using the `combined` format;
+in other environments the `dev` format is used.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "private": true,
   "dependencies": {
-    "express": "^4.18.2"
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server.js
+++ b/server.js
@@ -1,14 +1,20 @@
+require('dotenv').config();
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const morgan = require('morgan');
 const { router: authRouter, authenticateToken, requireRole } = require('./auth');
 
 const app = express();
+const logger = process.env.NODE_ENV === 'production'
+  ? morgan('combined', { stream: process.stdout })
+  : morgan('dev');
+app.use(logger);
 app.use(express.json());
 app.use(express.static(__dirname));
 app.use('/api', authRouter);
 
-const DATA_FILE = path.join(__dirname, 'airlines.json');
+const DATA_FILE = process.env.DATA_PATH || path.join(__dirname, 'airlines.json');
 
 function readData() {
   return JSON.parse(fs.readFileSync(DATA_FILE));


### PR DESCRIPTION
## Summary
- Load environment variables with dotenv in server
- Add morgan request logging and configurable data path
- Document environment variables and logging setup

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6898be8783e483219b334c0e25b2f76d