### PR TITLE
Add Docker configuration and usage guidance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+__tests__
+*.tmp
+tmp
+temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:lts
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Bundle app source
+COPY . .
+
+# Set and expose the port the app runs on
+ARG PORT=3000
+ENV PORT=$PORT
+EXPOSE $PORT
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,21 @@ Create a `.env` file or export variables in your shell.
 HTTP requests are logged using [`morgan`](https://www.npmjs.com/package/morgan).
 In production (`NODE_ENV=production`) logs are written to stdout using the `combined` format;
 in other environments the `dev` format is used.
+
+## Docker
+
+Build the image and run the container:
+
+```bash
+docker build -t airline-callsign-finder .
+docker run -p 3000:3000 -e PORT=3000 airline-callsign-finder
+```
+
+## Running without Docker
+
+When not containerized, use a process manager to keep the server running:
+
+```bash
+npm i -g pm2
+pm2 start server.js
+```


### PR DESCRIPTION
## Summary
- add Dockerfile using Node LTS, running `npm ci`, and exposing configurable `PORT`
- exclude test, node_modules, and temp files via `.dockerignore`
- document Docker build/run steps and using a process manager when not containerized

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c237b89483218263a158a073dc6d